### PR TITLE
Fix security: Gemini API key header, configurable API versions

### DIFF
--- a/client.go
+++ b/client.go
@@ -118,10 +118,14 @@ func (c *Client) chatOnce(ctx context.Context, providerName string, req *chat.Re
 		if apiKey == "" {
 			apiKey = c.cfg.OpenAIAPIKey
 		}
+		geminiModel := c.cfg.GeminiModel
+		if geminiModel == "" {
+			geminiModel = c.cfg.OpenAIModel
+		}
 		p, err := openai.New(openai.Config{
 			APIKey:       apiKey,
 			BaseURL:      base,
-			DefaultModel: c.cfg.OpenAIModel,
+			DefaultModel: geminiModel,
 			Debug:        c.cfg.Debug,
 		})
 		if err != nil {
@@ -134,6 +138,7 @@ func (c *Client) chatOnce(ctx context.Context, providerName string, req *chat.Re
 			APIKey:     c.cfg.AzureOpenAIAPIKey,
 			Endpoint:   c.cfg.AzureOpenAIEndpoint,
 			Deployment: c.cfg.AzureOpenAIModel,
+			APIVersion: c.cfg.AzureOpenAIAPIVersion,
 			Debug:      c.cfg.Debug,
 		})
 		if err != nil {

--- a/config.go
+++ b/config.go
@@ -12,9 +12,10 @@ type Config struct {
 	OpenAIModel   string
 
 	// Azure OpenAI
-	AzureOpenAIAPIKey   string
-	AzureOpenAIEndpoint string
-	AzureOpenAIModel    string
+	AzureOpenAIAPIKey      string
+	AzureOpenAIEndpoint    string
+	AzureOpenAIModel       string
+	AzureOpenAIAPIVersion  string
 
 	// Anthropic
 	AnthropicAPIKey string
@@ -39,6 +40,7 @@ type Config struct {
 	JinaAPIBase   string
 	GeminiAPIKey  string
 	GeminiAPIBase string
+	GeminiModel   string
 }
 
 const (

--- a/internal/providers/gemini/images.go
+++ b/internal/providers/gemini/images.go
@@ -281,13 +281,14 @@ func geminiPredictImagen(ctx context.Context, token string, geminiInput *GeminiC
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:predict?key=%s", geminiInput.Model, token)
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:predict", geminiInput.Model)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", token)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -394,9 +395,9 @@ func geminiGenerateContentOnce(ctx context.Context, token, model, prompt string,
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)
 	}
 
-	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s", model, token)
+	url := fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", model)
 	if strings.HasPrefix(model, "imagen-") {
-		url = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateImage?key=%s", model, token)
+		url = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateImage", model)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBody))
@@ -404,6 +405,7 @@ func geminiGenerateContentOnce(ctx context.Context, token, model, prompt string,
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", token)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -19,6 +19,7 @@ type Config struct {
 	APIKey     string
 	Endpoint   string
 	Deployment string
+	APIVersion string
 	Debug      bool
 }
 
@@ -37,8 +38,12 @@ func New(cfg Config) (*Provider, error) {
 	if cfg.Deployment == "" {
 		return nil, fmt.Errorf("azure openai deployment is required")
 	}
+	apiVersion := cfg.APIVersion
+	if apiVersion == "" {
+		apiVersion = azureAPIVersion
+	}
 	client := openai.NewClient(
-		azure.WithEndpoint(cfg.Endpoint, azureAPIVersion),
+		azure.WithEndpoint(cfg.Endpoint, apiVersion),
 		azure.WithAPIKey(cfg.APIKey),
 	)
 	return &Provider{


### PR DESCRIPTION
## Summary
- Move Gemini images API key from URL query param to `x-goog-api-key` header to prevent key leakage in logs and referrer headers
- Add `GeminiModel` config field with fallback to `OpenAIModel` for gemini chat provider
- Add `AzureOpenAIAPIVersion` config field with fallback to default `2024-08-01-preview`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Pre-existing test failures unrelated to this change (fixed in #2)