### PR TITLE
Add HTTP hardening: shared client with timeout and body limits

### DIFF
--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -1,0 +1,31 @@
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultTimeout      = 120 * time.Second
+	MaxResponseBodySize = 100 * 1024 * 1024 // 100 MB
+)
+
+// DefaultClient is a shared http.Client with a reasonable timeout.
+var DefaultClient = &http.Client{
+	Timeout: DefaultTimeout,
+}
+
+// ReadBody reads a response body with a size limit to prevent memory exhaustion.
+// Returns an error if the body exceeds MaxResponseBodySize.
+func ReadBody(body io.ReadCloser) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(body, MaxResponseBodySize+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > MaxResponseBodySize {
+		return nil, fmt.Errorf("response body exceeds %d bytes limit", MaxResponseBodySize)
+	}
+	return data, nil
+}

--- a/internal/providers/gemini/embeddings.go
+++ b/internal/providers/gemini/embeddings.go
@@ -5,11 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/lyricat/goutils/structs"
+	"github.com/quailyquaily/uniai/internal/httputil"
 )
 
 const (
@@ -77,13 +77,13 @@ func CreateEmbeddings(ctx context.Context, token, base string, inputs []string, 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("x-goog-api-key", token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/gemini/images.go
+++ b/internal/providers/gemini/images.go
@@ -8,11 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"image"
-	"io"
 	"net/http"
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/quailyquaily/uniai/internal/httputil"
 
 	"github.com/lyricat/goutils/structs"
 )
@@ -289,14 +290,14 @@ func geminiPredictImagen(ctx context.Context, token string, geminiInput *GeminiC
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := httputil.ReadBody(resp.Body)
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -405,14 +406,14 @@ func geminiGenerateContentOnce(ctx context.Context, token, model, prompt string,
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, _ := httputil.ReadBody(resp.Body)
 		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -466,13 +467,13 @@ func geminiDownloadImage(ctx context.Context, uri string) (string, string, error
 		return "", "", err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return "", "", err
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/providers/jina/classify.go
+++ b/internal/providers/jina/classify.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+
+	"github.com/quailyquaily/uniai/internal/httputil"
 )
 
 type ClassifyInput struct {
@@ -64,13 +65,13 @@ func Classify(ctx context.Context, token, base, model string, labels []string, i
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/jina/embeddings.go
+++ b/internal/providers/jina/embeddings.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/lyricat/goutils/structs"
+	"github.com/quailyquaily/uniai/internal/httputil"
 )
 
 type EmbeddingInput struct {
@@ -68,13 +68,13 @@ func CreateEmbeddings(ctx context.Context, token, base, model string, inputs []E
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/jina/rerank.go
+++ b/internal/providers/jina/rerank.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+
+	"github.com/quailyquaily/uniai/internal/httputil"
 )
 
 type RerankInput struct {
@@ -72,13 +73,13 @@ func Rerank(ctx context.Context, token, base, model, query string, docs []Rerank
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/openai/request.go
+++ b/internal/providers/openai/request.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
+
+	"github.com/quailyquaily/uniai/internal/httputil"
 )
 
 const (
@@ -24,13 +25,13 @@ func doRequest(ctx context.Context, token, base, method, path string, data []byt
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+token)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/providers/anthropic/anthropic.go
+++ b/providers/anthropic/anthropic.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
 	"github.com/lyricat/goutils/structs"
 	"github.com/quailyquaily/uniai/chat"
 	"github.com/quailyquaily/uniai/internal/diag"
+	"github.com/quailyquaily/uniai/internal/httputil"
 )
 
 type Config struct {
@@ -196,13 +196,13 @@ func (p *Provider) Chat(ctx context.Context, req *chat.Request) (*chat.Result, e
 	httpReq.Header.Set("x-api-key", p.cfg.APIKey)
 	httpReq.Header.Set("anthropic-version", "2023-06-01")
 
-	resp, err := http.DefaultClient.Do(httpReq)
+	resp, err := httputil.DefaultClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
-	respData, err := io.ReadAll(resp.Body)
+	respData, err := httputil.ReadBody(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Add `internal/httputil` package with `DefaultClient` (120s timeout) and `ReadBody` (100MB limit with explicit error on truncation)
- Replace `http.DefaultClient` with `httputil.DefaultClient` across all HTTP-calling providers (openai, jina, gemini, anthropic)
- Replace `io.ReadAll` with `httputil.ReadBody` to prevent memory exhaustion from unbounded response bodies
- Susanoo excluded (pending separate refactor)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Pre-existing test failures unrelated to this change (fixed in #2)