### PR TITLE
 feat(bedrock): add AwsSessionToken to Config for temporary credentials

### DIFF
--- a/client.go
+++ b/client.go
@@ -282,12 +282,13 @@ func (c *Client) chatOnce(ctx context.Context, providerName string, req *chat.Re
 
 	case "bedrock":
 		p := bedrock.New(bedrock.Config{
-			AwsKey:    c.cfg.AwsKey,
-			AwsSecret: c.cfg.AwsSecret,
-			AwsRegion: c.cfg.AwsRegion,
-			ModelArn:  c.cfg.AwsBedrockModelArn,
-			Headers:   c.cfg.ChatHeaders,
-			Debug:     c.cfg.Debug,
+			AwsKey:          c.cfg.AwsKey,
+			AwsSecret:       c.cfg.AwsSecret,
+			AwsSessionToken: c.cfg.AwsSessionToken,
+			AwsRegion:       c.cfg.AwsRegion,
+			ModelArn:        c.cfg.AwsBedrockModelArn,
+			Headers:         c.cfg.ChatHeaders,
+			Debug:           c.cfg.Debug,
 		})
 		return p.Chat(ctx, req)
 

--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	// AWS Bedrock
 	AwsKey             string
 	AwsSecret          string
+	AwsSessionToken    string
 	AwsRegion          string
 	AwsBedrockModelArn string
 

--- a/providers/bedrock/bedrock.go
+++ b/providers/bedrock/bedrock.go
@@ -19,12 +19,13 @@ import (
 )
 
 type Config struct {
-	AwsKey    string
-	AwsSecret string
-	AwsRegion string
-	ModelArn  string
-	Headers   map[string]string
-	Debug     bool
+	AwsKey          string
+	AwsSecret       string
+	AwsSessionToken string
+	AwsRegion       string
+	ModelArn        string
+	Headers         map[string]string
+	Debug           bool
 }
 
 type Provider struct {
@@ -41,7 +42,7 @@ func New(cfg Config) *Provider {
 	}
 	sess := session.Must(session.NewSession(&aws.Config{
 		Region:      aws.String(region),
-		Credentials: credentials.NewStaticCredentials(cfg.AwsKey, cfg.AwsSecret, ""),
+		Credentials: credentials.NewStaticCredentials(cfg.AwsKey, cfg.AwsSecret, cfg.AwsSessionToken),
 	}))
 	return &Provider{
 		client:   bedrockruntime.New(sess),


### PR DESCRIPTION
 ## Summary

  Adds `AwsSessionToken` to the Bedrock provider `Config` so that temporary AWS credentials (e.g. from STS / assumed role / SSO) can be forwarded
  through the uniai client into the underlying AWS SDK session.

  ## Changes

  | File | Change |
  |------|--------|
  | `config.go` | Add `AwsSessionToken string` to `Config` |
  | `providers/bedrock/bedrock.go` | Add `AwsSessionToken` to provider `Config`; pass it to `credentials.NewStaticCredentials` instead of hardcoded
  `""` |
  | `client.go` | Forward `c.cfg.AwsSessionToken` into `bedrock.Config` in `chatOnce` |

  ## Two-PR plan

  This PR is **PR 1 of 2**. The full end-to-end feature is split across repos:

  | PR | Repo | What it does | Status |
  |---|---|---|---|
  | **1** | `uniai` (this PR) | Add `AwsSessionToken` field to `Config` and wire it into the Bedrock provider | 🔄 Awaiting review |
  | **2** | `mistermorph` | Add `llm.bedrock.aws_profile` and `llm.bedrock.aws_session_token` config keys; resolve credentials via AWS SDK v2 before
  calling uniai | ⏳ Blocked on PR 1 |

  ### Why the split?

  `mistermorph` consumes `uniai` as a Go module. The session token must exist in `uniai.Config` **before** `mistermorph` can forward it. Without this
  PR, the token would be silently dropped at the uniai boundary.

  ### What happens after PR 1 is merged?

  Once this PR is merged and a new `uniai` version is published:

  1. `mistermorph` bumps its `go.mod` to the new uniai release
  2. `mistermorph` wires `aws_session_token` through to `uniai.Config.AwsSessionToken`
  3. `mistermorph` PR 2 can then be reviewed and merged

  ### Backwards compatibility

  This is a pure addition — existing callers that do not set `AwsSessionToken` will behave identically (the field defaults to `""`, which is the same
  as the previous hardcoded value).

  ## Testing

  - `go build ./...` compiles cleanly
  - No breaking changes to the public API