### PR TITLE
fix(openai): add ByteDance ARK empty content workaround

### DIFF
--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -28,6 +28,20 @@ Use the narrowest stable trigger available, prefer preserving provider metadata,
   - native Gemini is stricter and errors if `thought_signature` is missing
 - Tests: `providers/openai/openai_test.go`
 
+## ByteDance / Volces ARK
+
+- Path: `providers/openai/openai.go`
+- Trigger:
+  - model starts with `doubao-` or `ep-`
+  - or base URL host ends with `.volces.com` or contains `ark`
+- Behavior:
+  - assistant messages with empty `content` are padded with a single space `" "`
+  - tool messages with empty `content` are padded with `"(no output)"`
+- Notes:
+  - only applies to the `openai` provider path
+  - ARK rejects chat completion requests when any message has an empty `content` field
+- Tests: `providers/openai/openai_test.go`
+
 ## Gemini Native Tool Replay
 
 - Paths:

--- a/providers/openai/openai.go
+++ b/providers/openai/openai.go
@@ -103,6 +103,7 @@ func buildParams(req *chat.Request, defaultModel string, baseURL ...string) (ope
 		return openai.ChatCompletionNewParams{}, fmt.Errorf("openai provider model %q: %w", model, err)
 	}
 	applyKimiReasoningContentWorkaround(messages, model, firstNonEmpty(baseURL...))
+	applyByteDanceEmptyContentWorkaround(messages, model, firstNonEmpty(baseURL...))
 
 	params := openai.ChatCompletionNewParams{
 		Model:    openai.ChatModel(model),
@@ -240,4 +241,53 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
+}
+
+// applyByteDanceEmptyContentWorkaround fills empty message content for ByteDance
+// ARK-compatible endpoints, which reject requests when messages.content is empty.
+//
+// Assistant messages with no text are padded with a single space.
+// Tool messages with no output are padded with "(no output)".
+func applyByteDanceEmptyContentWorkaround(messages []openai.ChatCompletionMessageParamUnion, model, baseURL string) {
+	if !shouldApplyByteDanceEmptyContentWorkaround(model, baseURL) {
+		return
+	}
+	for i := range messages {
+		if assistant := messages[i].OfAssistant; assistant != nil {
+			if !assistant.Content.OfString.Valid() || strings.TrimSpace(assistant.Content.OfString.Value) == "" {
+				assistant.Content = openai.ChatCompletionAssistantMessageParamContentUnion{
+					OfString: openai.String(" "),
+				}
+			}
+			continue
+		}
+		if tool := messages[i].OfTool; tool != nil {
+			if !tool.Content.OfString.Valid() || strings.TrimSpace(tool.Content.OfString.Value) == "" {
+				tool.Content = openai.ChatCompletionToolMessageParamContentUnion{
+					OfString: openai.String("(no output)"),
+				}
+			}
+		}
+	}
+}
+
+func shouldApplyByteDanceEmptyContentWorkaround(model, baseURL string) bool {
+	normalizedModel := strings.ToLower(strings.TrimSpace(model))
+	normalizedModel = strings.TrimPrefix(normalizedModel, "models/")
+	if strings.HasPrefix(normalizedModel, "doubao-") || strings.HasPrefix(normalizedModel, "ep-") {
+		return true
+	}
+	return isByteDanceCompatibleBaseURL(baseURL)
+}
+
+func isByteDanceCompatibleBaseURL(baseURL string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return false
+	}
+	if !strings.EqualFold(parsed.Scheme, "https") {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return strings.HasSuffix(host, ".volces.com") || strings.Contains(host, "ark")
 }

--- a/providers/openai/openai_test.go
+++ b/providers/openai/openai_test.go
@@ -514,6 +514,143 @@ func TestBuildParamsNonKimiDoesNotInjectReasoningContent(t *testing.T) {
 	}
 }
 
+func TestBuildParamsByteDanceWorkaroundByModel(t *testing.T) {
+	req := &chat.Request{
+		Model: "doubao-pro-32k",
+		Messages: []chat.Message{
+			chat.User("run tool"),
+			{
+				Role: chat.RoleAssistant,
+				ToolCalls: []chat.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: chat.ToolCallFunction{
+							Name:      "read_file",
+							Arguments: `{"path":"/tmp/a.txt"}`,
+						},
+					},
+				},
+			},
+			chat.ToolResult("call_1", ""),
+		},
+	}
+
+	params, err := buildParams(req, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Assistant message with empty text should get a space
+	assistantContent := params.Messages[1].OfAssistant.Content.OfString.Value
+	if assistantContent != " " {
+		t.Fatalf("expected assistant content workaround ' ', got %q", assistantContent)
+	}
+
+	// Tool message with empty content should get "(no output)"
+	toolContent := params.Messages[2].OfTool.Content.OfString.Value
+	if toolContent != "(no output)" {
+		t.Fatalf("expected tool content workaround '(no output)', got %q", toolContent)
+	}
+}
+
+func TestBuildParamsByteDanceWorkaroundByBaseURL(t *testing.T) {
+	req := &chat.Request{
+		Model: "custom-model",
+		Messages: []chat.Message{
+			chat.User("run tool"),
+			{
+				Role: chat.RoleAssistant,
+				ToolCalls: []chat.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: chat.ToolCallFunction{
+							Name:      "read_file",
+							Arguments: `{"path":"/tmp/a.txt"}`,
+						},
+					},
+				},
+			},
+			chat.ToolResult("call_1", ""),
+		},
+	}
+
+	params, err := buildParams(req, "", "https://ark.cn-beijing.volces.com/api/v3")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assistantContent := params.Messages[1].OfAssistant.Content.OfString.Value
+	if assistantContent != " " {
+		t.Fatalf("expected assistant content workaround ' ', got %q", assistantContent)
+	}
+
+	toolContent := params.Messages[2].OfTool.Content.OfString.Value
+	if toolContent != "(no output)" {
+		t.Fatalf("expected tool content workaround '(no output)', got %q", toolContent)
+	}
+}
+
+func TestBuildParamsNonByteDanceDoesNotInjectContent(t *testing.T) {
+	req := &chat.Request{
+		Model: "gpt-4.1-mini",
+		Messages: []chat.Message{
+			chat.User("run tool"),
+			{
+				Role: chat.RoleAssistant,
+				ToolCalls: []chat.ToolCall{
+					{
+						ID:   "call_1",
+						Type: "function",
+						Function: chat.ToolCallFunction{
+							Name:      "read_file",
+							Arguments: `{"path":"/tmp/a.txt"}`,
+						},
+					},
+				},
+			},
+			chat.ToolResult("call_1", ""),
+		},
+	}
+
+	params, err := buildParams(req, "", "https://api.openai.com/v1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Assistant message should not have content injected
+	if params.Messages[1].OfAssistant.Content.OfString.Valid() {
+		t.Fatalf("non-bytedance request should not inject assistant content")
+	}
+
+	// Tool message should remain empty
+	if params.Messages[2].OfTool.Content.OfString.Valid() && params.Messages[2].OfTool.Content.OfString.Value != "" {
+		t.Fatalf("non-bytedance request should not inject tool content, got %q", params.Messages[2].OfTool.Content.OfString.Value)
+	}
+}
+
+func TestShouldApplyByteDanceEmptyContentWorkaround(t *testing.T) {
+	tests := []struct {
+		name    string
+		model   string
+		baseURL string
+		want    bool
+	}{
+		{name: "doubao model", model: "doubao-pro-32k", want: true},
+		{name: "ep model", model: "ep-20240101-xxxxx", want: true},
+		{name: "volces base", model: "custom-model", baseURL: "https://ark.cn-beijing.volces.com/api/v3", want: true},
+		{name: "ark subdomain", model: "custom-model", baseURL: "https://ark.example.com/api/v3", want: true},
+		{name: "non bytedance", model: "gpt-4.1-mini", baseURL: "https://api.openai.com/v1", want: false},
+	}
+
+	for _, tc := range tests {
+		if got := shouldApplyByteDanceEmptyContentWorkaround(tc.model, tc.baseURL); got != tc.want {
+			t.Fatalf("%s: expected %v, got %v", tc.name, tc.want, got)
+		}
+	}
+}
+
 func TestShouldApplyKimiReasoningContentWorkaround(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

  ByteDance ARK (Volces) rejects chat completion requests
  when `messages.content` is an empty string. This happens
  when:

  - The assistant returns a tool call without any
  accompanying text
  - A tool execution produces no observable output

  ## Changes

  | File | Change |
  |------|--------|
  | `providers/openai/openai.go` | Add
  `applyByteDanceEmptyContentWorkaround` — assistant
  messages → `" "`, tool messages → `"(no output)"` |
  | `providers/openai/openai_test.go` | Add 4 tests
  covering model trigger, base URL trigger, non-ByteDance
  exclusion, and trigger logic |
  | `docs/workarounds.md` | Document the workaround |

  ## Trigger

  - model starts with `doubao-` or `ep-`
  - or base URL host ends with `.volces.com` or contains
  `ark`

  ## Backwards compatibility

  Only applies to ByteDance ARK-compatible endpoints. Other
   OpenAI-compatible providers are unaffected.